### PR TITLE
chore: 토큰 만료기간 변경

### DIFF
--- a/src/main/java/dnd/dnd10_backend/config/jwt/JwtProperties.java
+++ b/src/main/java/dnd/dnd10_backend/config/jwt/JwtProperties.java
@@ -14,8 +14,8 @@ package dnd.dnd10_backend.config.jwt;
  */
 public interface JwtProperties {
     String SECRET = "DND810";
-    Long AT_EXP_TIME =  60000L * 5; //30분 //60000 1분 //864000000 10일
-    Long RT_EXP_TIME = 60000L * 7; //1주일
+    Long AT_EXP_TIME =  60000L * 30; //30분
+    Long RT_EXP_TIME = 60000L * 60 * 24 * 14; //14일 (2주)
     String TOKEN_PREFIX = "Bearer ";
     String AT_HEADER_STRING = "Authorization";
     String RT_HEADER_STRING = "Refresh";


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#7-user-manage -> develop

### 변경 사항
access token의 만료기간을 30분
refresh token의 만료기간을 2주로 설정했습니다.

### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/7
