### PR TITLE
feat:기본 시재 저장 및 시재 관리 기능 추가

### DIFF
--- a/src/main/java/dnd/dnd10_backend/Inventory/controller/InventoryController.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/controller/InventoryController.java
@@ -1,6 +1,8 @@
 package dnd.dnd10_backend.Inventory.controller;
 
 import dnd.dnd10_backend.Inventory.domain.enums.Category;
+import dnd.dnd10_backend.Inventory.dto.request.CreateInventoryRequestDto;
+import dnd.dnd10_backend.Inventory.dto.request.UpdateInventoryListRequestDto;
 import dnd.dnd10_backend.Inventory.dto.response.InventoryResponseDto;
 import dnd.dnd10_backend.Inventory.service.InventoryService;
 import dnd.dnd10_backend.common.domain.SingleResponse;
@@ -37,7 +39,7 @@ public class InventoryController {
 
     /**
      * 시재 조회 api
-     * @param category
+     * @param category 조회하려는 카테고리
      * @param request
      * @return
      */
@@ -56,6 +58,46 @@ public class InventoryController {
 
         SingleResponse<List<InventoryResponseDto>> response = responseService.getResponse(responseDtoList,
                                                                           CodeStatus.SUCCESS_SEARCHED_INVENTORY);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * 시재 저장 api (담배만 새로 추가 가능)
+     * @param requestDto
+     * @param request
+     * @return
+     */
+    @PostMapping("/inventory")
+    public ResponseEntity createInventory(@RequestBody CreateInventoryRequestDto requestDto,
+                                                  HttpServletRequest request){
+        String token = request.getHeader(JwtProperties.AT_HEADER_STRING)
+                .replace(JwtProperties.TOKEN_PREFIX,"");
+
+        List<InventoryResponseDto> responseDtoList = inventoryService.saveInventory(requestDto, token);
+
+        SingleResponse<List<InventoryResponseDto>> response = responseService.getResponse(responseDtoList,
+                CodeStatus.SUCCESS_CREATED_INVENTORY);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     *
+     * @param requestDto
+     * @param request
+     * @return
+     */
+    @PutMapping("/inventory")
+    public ResponseEntity updateInventory(@RequestBody UpdateInventoryListRequestDto requestDto,
+                                                HttpServletRequest request){
+        String token = request.getHeader(JwtProperties.AT_HEADER_STRING)
+                .replace(JwtProperties.TOKEN_PREFIX,"");
+
+        List<InventoryResponseDto> responseDtoList = inventoryService.updateInventory(requestDto, token);
+
+        SingleResponse<List<InventoryResponseDto>> response = responseService.getResponse(responseDtoList,
+                CodeStatus.SUCCESS_UPDATED_INVENTORY);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/dnd/dnd10_backend/Inventory/domain/DefaultInventory.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/domain/DefaultInventory.java
@@ -1,11 +1,6 @@
 package dnd.dnd10_backend.Inventory.domain;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import dnd.dnd10_backend.Inventory.domain.enums.Category;
-import dnd.dnd10_backend.store.domain.Store;
-import dnd.dnd10_backend.user.domain.enums.Role;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -13,9 +8,9 @@ import javax.persistence.*;
 
 /**
  * 패키지명 dnd.dnd10_backend.Inventory.domain
- * 클래스명 Inventory
- * 클래스설명
- * 작성일 2023-02-08
+ * 클래스명 DefaultInventory
+ * 클래스설명 편의점에 기본적으로 제공해줄 시재 entity
+ * 작성일 2023-02-11
  *
  * @author 원지윤
  * @version 1.0
@@ -25,8 +20,8 @@ import javax.persistence.*;
 @Entity
 @Data
 @NoArgsConstructor
-@Table(name = "inventory")
-public class Inventory {
+@Table(name = "default_inventory")
+public class DefaultInventory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "inventory_idx")
@@ -38,16 +33,4 @@ public class Inventory {
     @Column(name = "category")
     @Enumerated(EnumType.STRING)
     private Category category;
-
-    @ManyToOne
-    @JoinColumn(name = "store_idx")
-    private Store store;
-
-    @Builder
-    public Inventory(String inventoryName, Category category, Store store){
-        this.inventoryName = inventoryName;
-        this.category = category;
-        this.store = store;
-    }
-
 }

--- a/src/main/java/dnd/dnd10_backend/Inventory/domain/InventoryUpdateRecord.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/domain/InventoryUpdateRecord.java
@@ -1,0 +1,66 @@
+package dnd.dnd10_backend.Inventory.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dnd.dnd10_backend.Inventory.domain.enums.Category;
+import dnd.dnd10_backend.Inventory.dto.request.UpdateInventoryRequestDto;
+import dnd.dnd10_backend.store.domain.Store;
+import dnd.dnd10_backend.user.domain.User;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.domain
+ * 클래스명 InventoryUpdateRecord
+ * 클래스설명 시재 업데이트 이력에 대한 entity
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Entity
+@Data
+@NoArgsConstructor
+@Table(name = "inventory_record")
+public class InventoryUpdateRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_idx")
+    private Long recordIdx;
+
+    @Column(name="inventory_name")
+    private String inventoryName;
+
+    @Column(name="diff")
+    private int diff;
+
+    @Column(name = "category")
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @ManyToOne
+    @JoinColumn(name = "user_code")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "store_idx")
+    private Store store;
+
+    @CreationTimestamp
+    private LocalDateTime createTime;
+
+    @Builder
+    public InventoryUpdateRecord(Inventory inventory, int diff, Category category, User user, Store store){
+        this.inventoryName = inventory.getInventoryName();
+        this.diff = diff;
+        this.category = category;
+        this.user = user;
+        this.store = store;
+    }
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/domain/enums/Category.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/domain/enums/Category.java
@@ -6,6 +6,17 @@ import dnd.dnd10_backend.Inventory.domain.Inventory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.domain.enums
+ * 클래스명 Category
+ * 클래스설명
+ * 작성일 2023-02-10
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
 @Getter
 @AllArgsConstructor
 public enum Category {

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/request/CreateInventoryRequestDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/request/CreateInventoryRequestDto.java
@@ -1,0 +1,25 @@
+package dnd.dnd10_backend.Inventory.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.dto.request
+ * 클래스명 CreateInventoryRequestDto
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateInventoryRequestDto {
+    private String inventoryName;
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryListRequestDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryListRequestDto.java
@@ -1,0 +1,29 @@
+package dnd.dnd10_backend.Inventory.dto.request;
+
+import dnd.dnd10_backend.Inventory.domain.enums.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.dto.request
+ * 클래스명 UpdateInventoryListRequestDto
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateInventoryListRequestDto {
+    private Category category;
+    private List<UpdateInventoryRequestDto> list;
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryRequestDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryRequestDto.java
@@ -1,0 +1,27 @@
+package dnd.dnd10_backend.Inventory.dto.request;
+
+import dnd.dnd10_backend.Inventory.domain.enums.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.dto.request
+ * 클래스명 UpdateInventoryRequestDto
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateInventoryRequestDto {
+    private String inventoryName;
+    private int diff;
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
@@ -1,0 +1,27 @@
+package dnd.dnd10_backend.Inventory.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.dto.response
+ * 클래스명 InventoryRecordListResponseDto
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class InventoryRecordListResponseDto {
+    private String userName;
+    private String workTime;
+    List<InventoryRecordResponseDto> list;
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordResponseDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordResponseDto.java
@@ -1,0 +1,33 @@
+package dnd.dnd10_backend.Inventory.dto.response;
+
+import dnd.dnd10_backend.Inventory.domain.InventoryUpdateRecord;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.dto.response
+ * 클래스명 InventoryRecordResponseDto
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class InventoryRecordResponseDto {
+    private String inventoryName;
+    private int diff;
+
+    public static InventoryRecordResponseDto of(InventoryUpdateRecord updateRecord){
+        return new InventoryRecordResponseDto(
+                updateRecord.getInventoryName(),
+                updateRecord.getDiff()
+        );
+
+    }
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryResponseDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryResponseDto.java
@@ -23,14 +23,12 @@ import lombok.NoArgsConstructor;
 public class InventoryResponseDto {
     private Long inventoryIdx;
     private String inventoryName;
-    private int inventoryCount;
     private Category category;
 
     public static InventoryResponseDto of(Inventory inventory){
         return new InventoryResponseDto(
                 inventory.getInventoryIdx(),
                 inventory.getInventoryName(),
-                inventory.getInventoryCount(),
                 inventory.getCategory()
         );
     }

--- a/src/main/java/dnd/dnd10_backend/Inventory/repository/DefaultInventoryRepository.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/repository/DefaultInventoryRepository.java
@@ -1,0 +1,18 @@
+package dnd.dnd10_backend.Inventory.repository;
+
+import dnd.dnd10_backend.Inventory.domain.DefaultInventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.repository
+ * 클래스명 DefaultInventoryRepository
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+public interface DefaultInventoryRepository extends JpaRepository<DefaultInventory,Long> {
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryRepository.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryRepository.java
@@ -22,9 +22,11 @@ import java.util.List;
  * 예시) [2022-09-17] 주석추가 - 원지윤
  */
 public interface InventoryRepository extends JpaRepository<Inventory, Long> {
-    @Query("select i from Inventory i where i.store = :store group by i.category")
+    @Query("select i from Inventory i where i.store = :store order by i.category")
     public List<Inventory> findAllByStore(@Param("store")Store store);
 
     public List<Inventory> findInventoryByCategoryAndStore(Category category, Store store);
+
+    public Inventory findInventoryByInventoryName(String inventoryName);
 
 }

--- a/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryUpdateRecordRepository.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryUpdateRecordRepository.java
@@ -1,0 +1,19 @@
+package dnd.dnd10_backend.Inventory.repository;
+
+import dnd.dnd10_backend.Inventory.domain.InventoryUpdateRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.repository
+ * 클래스명 InventoryUpdateRecordRepository
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+public interface InventoryUpdateRecordRepository extends JpaRepository<InventoryUpdateRecord, Long> {
+
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/service/DefaultInventoryService.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/service/DefaultInventoryService.java
@@ -1,0 +1,50 @@
+package dnd.dnd10_backend.Inventory.service;
+
+import dnd.dnd10_backend.Inventory.domain.DefaultInventory;
+import dnd.dnd10_backend.Inventory.domain.Inventory;
+import dnd.dnd10_backend.Inventory.repository.DefaultInventoryRepository;
+import dnd.dnd10_backend.Inventory.repository.InventoryRepository;
+import dnd.dnd10_backend.store.domain.Store;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.service
+ * 클래스명 DefaultInventoryService
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Service
+public class DefaultInventoryService {
+    @Autowired
+    private DefaultInventoryRepository defaultInventoryRepository;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    /**
+     * 기본 시재들을 저장하는 메소드
+     * @param store
+     */
+    public void saveDafaultInventories(Store store){
+        List<DefaultInventory> list = defaultInventoryRepository.findAll();
+
+        for(DefaultInventory i: list){
+            Inventory inventory = Inventory.builder()
+                    .inventoryName(i.getInventoryName())
+                    .category(i.getCategory())
+                    .store(store)
+                    .build();
+
+            inventoryRepository.save(inventory);
+        }
+        return;
+    }
+}

--- a/src/main/java/dnd/dnd10_backend/Inventory/service/InventoryRecordService.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/service/InventoryRecordService.java
@@ -1,0 +1,34 @@
+package dnd.dnd10_backend.Inventory.service;
+
+import dnd.dnd10_backend.Inventory.repository.InventoryUpdateRecordRepository;
+import dnd.dnd10_backend.store.domain.Store;
+import dnd.dnd10_backend.user.domain.User;
+import dnd.dnd10_backend.user.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * 패키지명 dnd.dnd10_backend.Inventory.service
+ * 클래스명 InventoryRecordService
+ * 클래스설명
+ * 작성일 2023-02-11
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Service
+public class InventoryRecordService {
+    @Autowired
+    private InventoryUpdateRecordRepository recordRepository;
+
+    @Autowired
+    private UserService userService;
+
+    public void findInventoryUpdateRecords(final String token){
+        User user = userService.getUserByEmail(token);
+        Store store = user.getStore();
+
+    }
+}

--- a/src/main/java/dnd/dnd10_backend/common/domain/enums/CodeStatus.java
+++ b/src/main/java/dnd/dnd10_backend/common/domain/enums/CodeStatus.java
@@ -34,6 +34,8 @@ public enum CodeStatus {
     SUCCESS_CREATED_CHECKLIST(201, "체크리스트 등록에 성공하였습니다."),
 
     SUCCESS_SEARCHED_INVENTORY(200, "시재 조회에 성공하였습니다."),
+    SUCCESS_CREATED_INVENTORY(201, "시재 등록에 성공하였습니다."),
+    SUCCESS_UPDATED_INVENTORY(200, "시재 업데이트에 성공하였습니다."),
 
     //40X
     ACCESS_TOKEN_EXPIRED(401,"엑세스 토큰이 만료되었습니다."),
@@ -44,7 +46,8 @@ public enum CodeStatus {
     NOT_FOUND_TIMECARD(404,"찾을 수 없는 근무이력입니다."),
     NOT_FOUND_CHECKLIST(404,"찾을 수 없는 체크리스트입니다."),
     UNAUTHORIZED_DELETED_USER(401,"삭제 가능한 사용자가 아닙니다."),
-    UNAUTHORIZED_UPDATED_USER(401,"업데이트 가능한 사용자가 아닙니다.");
+    UNAUTHORIZED_UPDATED_USER(401,"업데이트 가능한 사용자가 아닙니다."),
+    ALREADY_CREATED_INVENTORY(400, "이미 존재하는 담배입니다.");
 
 
     private final int code;

--- a/src/main/java/dnd/dnd10_backend/user/domain/User.java
+++ b/src/main/java/dnd/dnd10_backend/user/domain/User.java
@@ -33,6 +33,7 @@ import java.util.List;
  * [2023-02-06] timecard 연관관계 매핑 추가 - 이우진
  * [2023-02-08] 카카오 프로필 삭제 - 원지윤
  * [2023-02-10] store연관 관계 추가 - 원지윤
+ * [2023-02-11] workPlace 삭제
  */
 @Entity
 @Data
@@ -62,9 +63,6 @@ public class User implements UserDetails {
 
     @Column(name = "phone_number")
     private String phoneNumber;
-
-    @Column(name = "work_place")
-    private String workPlace;
 
     @Column(name = "work_time")
     private String workTime;
@@ -97,7 +95,6 @@ public class User implements UserDetails {
     public void updateUser(UserSaveRequestDto requestDto) {
         this.role = requestDto.getRole();
         this.phoneNumber = requestDto.getPhoneNumber();
-        this.workPlace = requestDto.getWorkPlace();
         this.workTime = requestDto.getWorkTime();
     }
 

--- a/src/main/java/dnd/dnd10_backend/user/service/UserService.java
+++ b/src/main/java/dnd/dnd10_backend/user/service/UserService.java
@@ -1,6 +1,9 @@
 package dnd.dnd10_backend.user.service;
 
 import com.auth0.jwt.algorithms.Algorithm;
+import dnd.dnd10_backend.Inventory.repository.DefaultInventoryRepository;
+import dnd.dnd10_backend.Inventory.service.DefaultInventoryService;
+import dnd.dnd10_backend.Inventory.service.InventoryService;
 import dnd.dnd10_backend.common.domain.enums.CodeStatus;
 import dnd.dnd10_backend.common.exception.CustomerNotFoundException;
 import dnd.dnd10_backend.config.jwt.JwtProperties;
@@ -34,10 +37,13 @@ import static com.auth0.jwt.JWT.require;
 public class UserService {
 
     @Autowired
-    UserRepository userRepository;
+    private UserRepository userRepository;
 
     @Autowired
-    StoreRepository storeRepository;
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private DefaultInventoryService defaultInventoryService;
 
     /**
      * 토큰 정보로 사용자를 조회하는 메소드
@@ -85,7 +91,8 @@ public class UserService {
                     .storeName(requestDto.getWorkPlace())
                     .build();
 
-            storeRepository.save(store);
+            store = storeRepository.save(store);
+            defaultInventoryService.saveDafaultInventories(store);
         }
 
         int count = userRepository.findByStore(store).size();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#30-inventory-manage -> develop
### 변경 사항
- 시재 조회 및 시재 관리 기능을 추가하였습니다.
- 시재 업데이트에 대한 이력 엔티티 추가
- 유저 추가 시 새로운 store가 등록되면 기본 시재를 자동으로 저장하도록 하였습니다.

### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/30
