### PR TITLE
feat: 체크리스트 일주일 상태 확인 기능 구현

### DIFF
--- a/src/main/java/dnd/dnd10_backend/checkList/controller/CheckListController.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/controller/CheckListController.java
@@ -27,6 +27,7 @@ import java.util.List;
  * [수정내용]
  * 예시) [2022-09-17] 주석추가 - 원지윤
  * [2023-02-08] 체크리스트 조회를 dto -> String으로 변경 - 원지윤
+ * [2023-02-13] 체크리스트 일주일 상태 확인 api 추가 - 원지윤
  */
 @RestController
 @RequestMapping("/api")

--- a/src/main/java/dnd/dnd10_backend/checkList/controller/CheckListController.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/controller/CheckListController.java
@@ -111,10 +111,29 @@ public class CheckListController {
                                           HttpServletRequest request){
         String token = request.getHeader(JwtProperties.AT_HEADER_STRING)
                 .replace(JwtProperties.TOKEN_PREFIX,"");
+
         List<CheckListResponseDto> responseDto = checkListService.deleteCheckList(checkIdx, token);
 
         SingleResponse<List<CheckListResponseDto>> response
                 = responseService.getResponse(responseDto, CodeStatus.SUCCESS_DELETED_CHECKLIST);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * 체크리스트 일주일 상태 확인하는 api
+     * @param request
+     * @return
+     */
+    @GetMapping("/checkList/week")
+    public ResponseEntity showWeekStatus(HttpServletRequest request){
+        String token = request.getHeader(JwtProperties.AT_HEADER_STRING)
+                .replace(JwtProperties.TOKEN_PREFIX,"");
+
+        List<Boolean> responseList = checkListService.checkWeek(token);
+
+        SingleResponse<List<Boolean>> response
+                = responseService.getResponse(responseList,CodeStatus.SUCCESS);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/dnd/dnd10_backend/checkList/domain/CheckList.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/domain/CheckList.java
@@ -6,6 +6,7 @@ import dnd.dnd10_backend.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -26,6 +27,7 @@ import java.util.Date;
  * @version 1.0
  * [수정내용]
  * 예시) [2022-09-17] 주석추가 - 원지윤
+ * [2023-02-13] column애 대한 nullable 설정 및 default 지정 - 원지윤
  */
 @Entity
 @Data
@@ -37,13 +39,14 @@ public class CheckList {
     @Column(name = "check_idx")
     private Long checkIdx;
 
-    @Column(name = "check_date")
+    @Column(name = "check_date",nullable = false)
     private LocalDate date;
 
     @Column(name = "content")
     private String content;
 
-    @Column(name = "status")
+    @Column(name = "status",nullable = false)
+    @ColumnDefault("N")
     private String status;
 
     @Column(name = "create_time",nullable = false,updatable = false)

--- a/src/main/java/dnd/dnd10_backend/checkList/repository/CheckListRepository.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/repository/CheckListRepository.java
@@ -30,4 +30,6 @@ public interface CheckListRepository extends JpaRepository<CheckList, Long> {
 
     @Override
     Optional<CheckList> findById(Long checkIdx);
+
+    public List<CheckList> findCheckListByDateAndAndStatusAndUser(LocalDate date, String status, User user);
 }

--- a/src/main/java/dnd/dnd10_backend/checkList/repository/CheckListRepository.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/repository/CheckListRepository.java
@@ -22,6 +22,7 @@ import java.util.Optional;
  * [수정내용]
  * 예시) [2022-09-17] 주석추가 - 원지윤
  * [2023-02-08] 체크리스트 order by 추가 - 원지윤
+ * [2023-02-13] 체크리스트 date, status로 체크리스트 찾도록 추가 - 원지윤
  */
 public interface CheckListRepository extends JpaRepository<CheckList, Long> {
     @Query(value = "select * from (select * from check_list c1 where c1.user_code = :user and c1.check_date = :date and c1.status = 'N' order by c1.create_time DESC LIMIT 1000000) as A " + "UNION ALL "

--- a/src/main/java/dnd/dnd10_backend/checkList/service/CheckListService.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/service/CheckListService.java
@@ -12,11 +12,14 @@ import dnd.dnd10_backend.common.exception.CustomerNotFoundException;
 import dnd.dnd10_backend.config.jwt.JwtProperties;
 import dnd.dnd10_backend.user.domain.User;
 import dnd.dnd10_backend.user.repository.UserRepository;
+import dnd.dnd10_backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
@@ -46,6 +49,8 @@ public class CheckListService {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private UserService userService;
     /**
      * 체크리스트 저장하는 메소드
      * @param token
@@ -53,11 +58,8 @@ public class CheckListService {
      * @return
      */
     public List<CheckListResponseDto> saveCheckList(CheckListRequestDto requestDto, final String token){
-        String email = require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                .getClaim("email").asString();
-
         //user 찾기
-        User user = userRepository.findByKakaoEmail(email);
+        User user = userService.getUserByEmail(token);
         if(user == null) throw new CustomerNotFoundException(CodeStatus.NOT_FOUND_USER);
 
         CheckList checkList = CheckList.builder()
@@ -79,11 +81,8 @@ public class CheckListService {
      * @return
      */
     public WorkCheckListResponseDto findCheckList(final String date, final String token){
-        String email = require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                .getClaim("email").asString();
-
         //user 찾기
-        User user = userRepository.findByKakaoEmail(email);
+        User user = userService.getUserByEmail(token);
 
         if(user == null) throw new CustomerNotFoundException(CodeStatus.NOT_FOUND_USER);
 
@@ -103,11 +102,8 @@ public class CheckListService {
      * @return
      */
     public List<CheckListResponseDto> deleteCheckList(Long checkIdx, final String token){
-        String email = require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                .getClaim("email").asString();
-
         //user 찾기
-        User user = userRepository.findByKakaoEmail(email);
+        User user = userService.getUserByEmail(token);
 
         if(user == null) throw new CustomerNotFoundException(CodeStatus.NOT_FOUND_USER);
 
@@ -128,11 +124,8 @@ public class CheckListService {
      * @param token
      */
     public List<CheckListResponseDto> updateCheckList(UpdateCheckListRequestDto requestDto, final String token){
-        String email = require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                .getClaim("email").asString();
-
         //user 찾기
-        User user = userRepository.findByKakaoEmail(email);
+        User user = userService.getUserByEmail(token);
 
         if(user == null) throw new CustomerNotFoundException(CodeStatus.NOT_FOUND_USER);
         
@@ -162,6 +155,34 @@ public class CheckListService {
         String DOW = dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN);
 
         return user.getWorkTime().contains(DOW.subSequence(0,1));
+    }
+
+    /**
+     *
+     * @param token access token
+     * @return
+     */
+    public List<Boolean> checkWeek(final String token){
+        List<Boolean> weekStatus = new ArrayList<>();
+        User user = userService.getUserByEmail(token);
+
+        LocalDate now = LocalDate.now(ZoneId.of("Asia/Seoul")); // 현재시간
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+        int dayOfWeekNumber = dayOfWeek.getValue(); //월 - 1 일 - 7
+
+        LocalDate startDay = now.minusDays(dayOfWeekNumber);
+
+        for(int i=0;i<7;i++){
+            List<CheckList> list = checkListRepository
+                    .findCheckListByDateAndAndStatusAndUser(startDay.plusDays(i),"N", user);
+            if(list.size()>0){
+                weekStatus.add(true);
+            }
+            else{
+                weekStatus.add(false);
+            }
+        }
+        return weekStatus;
     }
 
     /**

--- a/src/main/java/dnd/dnd10_backend/checkList/service/CheckListService.java
+++ b/src/main/java/dnd/dnd10_backend/checkList/service/CheckListService.java
@@ -40,6 +40,8 @@ import static com.auth0.jwt.JWT.require;
  * 예시) [2022-09-17] 주석추가 - 원지윤
  * [2023-02-08] 체크리스트 조회를 dto -> String으로 변경 - 원지윤
  * [2023-02-08] 체크리스트 삭제, 업데이트 시 사용자 확인 - 원지윤
+ * [2023-02-13] 체크리스트 일주일 상태 확인 메소드 추가 - 원지윤
+ * [2023-02-13] userService 추가 및 토큰으로 사용자 찾는 부분 변경 - 원지윤
  */
 @Service
 public class CheckListService {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#29-check-week -> develop

### 변경 사항
- 오늘 날짜를 기준으로 오늘 날짜가 포함된 week에 대한 체크리스트가 남아있는 상태를 조회할 수 있는 api 추가
- 위 관련 메소드 추가
- 주석 추가

### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/29
