### PR TITLE
fix: 카테고리별 시재 기록 조회 수정

### DIFF
--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
@@ -19,20 +19,21 @@ import java.util.List;
  * @version 1.0
  * [수정내용]
  * 예시) [2022-09-17] 주석추가 - 원지윤
+ * [2023-02-14] role 삭제 및 workDay 추가 - 원지윤
  */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class InventoryRecordListResponseDto {
     private String userName;
-    private Role role;
+    private String workDay;
     private String workTime;
     List<InventoryRecordResponseDto> list;
 
     public static InventoryRecordListResponseDto of(User user, TimeCard timeCard, List<InventoryRecordResponseDto> list){
         return new InventoryRecordListResponseDto(
                 user.getUsername(),
-                user.getRole(),
+                timeCard.getMonth() + "월"+ timeCard.getDay()+"일",
                 timeCard.getWorkTime(),
                 list
 

--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/response/InventoryRecordListResponseDto.java
@@ -20,12 +20,14 @@ import java.util.List;
  * [수정내용]
  * 예시) [2022-09-17] 주석추가 - 원지윤
  * [2023-02-14] role 삭제 및 workDay 추가 - 원지윤
+ * [2023-02-14] userProfileCode 추가 - 원지윤
  */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class InventoryRecordListResponseDto {
     private String userName;
+    private int userProfileCode;
     private String workDay;
     private String workTime;
     List<InventoryRecordResponseDto> list;
@@ -33,6 +35,7 @@ public class InventoryRecordListResponseDto {
     public static InventoryRecordListResponseDto of(User user, TimeCard timeCard, List<InventoryRecordResponseDto> list){
         return new InventoryRecordListResponseDto(
                 user.getUsername(),
+                user.getUserProfileCode(),
                 timeCard.getMonth() + "월"+ timeCard.getDay()+"일",
                 timeCard.getWorkTime(),
                 list

--- a/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryUpdateRecordRepository.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/repository/InventoryUpdateRecordRepository.java
@@ -27,6 +27,8 @@ public interface InventoryUpdateRecordRepository extends JpaRepository<Inventory
     @Query("select i from InventoryUpdateRecord i where i.createTime <= :date")
     public List<InventoryUpdateRecord> findPastRecord(@Param("date")LocalDateTime endDateTime);
 
+    public List<InventoryUpdateRecord> findByTimeCardAndCategory(TimeCard timeCard, Category category);
+
     public List<InventoryUpdateRecord> findByTimeCard(TimeCard timeCard);
 
     @Query("select i from InventoryUpdateRecord i where i.store = :store group by i.timeCard order by i.createTime desc")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#30-inventory-response

### 변경 사항
- 카테고리별 시재 기록 조회가 안되는 오류 수정하였습니다.
- 시재 기록 조회 시 userProfileCode도 함께 전달 하도록 변경하였습니다.
### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/30
