### PR TITLE
fix: 카카오 소셜 로그인 이메일 제공 미동의시 에러 처리

### DIFF
--- a/src/main/java/dnd/dnd10_backend/common/domain/enums/CodeStatus.java
+++ b/src/main/java/dnd/dnd10_backend/common/domain/enums/CodeStatus.java
@@ -52,6 +52,7 @@ public enum CodeStatus {
     SUCCESS_DELETED_INVENTORY(200, "시재 삭제에 성공하였습니다."),
 
     //40X
+    USER_EMAIL_NULL(400, "사용자 이메일 미제공"),
     ACCESS_TOKEN_EXPIRED(401,"엑세스 토큰이 만료되었습니다."),
     REFRESH_TOKEN_EXPIRED(401,"리프레쉬 토큰이 만료되었습니다."),
     INVALID_TOKEN(401,"유효하지 않은 토큰입니다."),
@@ -62,7 +63,6 @@ public enum CodeStatus {
     NOT_FOUND_POST(404, "찾을 수 없는 게시글입니다."),
     NOT_FOUND_COMMENT(404, "찾을 수 없는 댓글입니다."),
     NOT_FOUND_INVENTORY(404,"찾을 수 없는 시재입니다."),
-
     UNAUTHORIZED_DELETED_USER(401,"삭제 가능한 사용자가 아닙니다."),
     UNAUTHORIZED_UPDATED_USER(401,"업데이트 가능한 사용자가 아닙니다."),
     ALREADY_CREATED_INVENTORY(400, "이미 존재하는 담배입니다.");

--- a/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
+++ b/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
@@ -111,7 +111,12 @@ public class TokenService {
     public List<String> saveUserAndGetToken(String token) {
         KakaoProfile profile = findProfile(token);
         List<String> tokenList = new ArrayList<>();
+
+        if(profile.getKakao_account().getEmail().equals(null))
+            throw new CustomerNotFoundException("");
+
         User user = userRepository.findByKakaoEmail(profile.getKakao_account().getEmail());
+
         if(user == null) {
             user = User.builder()
                     .kakaoId(profile.getId())

--- a/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
+++ b/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
@@ -112,8 +112,9 @@ public class TokenService {
         KakaoProfile profile = findProfile(token);
         List<String> tokenList = new ArrayList<>();
 
-        if(profile.getKakao_account().getEmail().equals(null))
-            throw new CustomerNotFoundException("");
+        if(profile.getKakao_account().getEmail().equals(null)) {
+            throw new CustomerNotFoundException(CodeStatus.USER_EMAIL_NULL);
+        }
 
         User user = userRepository.findByKakaoEmail(profile.getKakao_account().getEmail());
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#132-kakao-email -> develop

### 변경 사항
- 카카오 소셜 로그인 시 이메일 제공 미동의시 Exception처리를 하였습니다.

### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/132
