### PR TITLE
fix: 카카오 이메일 제공 미동의 시 임의의 메일 넣기

### DIFF
--- a/src/main/java/dnd/dnd10_backend/user/domain/User.java
+++ b/src/main/java/dnd/dnd10_backend/user/domain/User.java
@@ -9,6 +9,7 @@ import dnd.dnd10_backend.user.domain.enums.Role;
 import dnd.dnd10_backend.user.dto.request.UserSaveRequestDto;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.security.core.GrantedAuthority;
@@ -42,7 +43,7 @@ import java.util.List;
  * [2023-02-24] 토큰 연관관계 추가 - 원지윤
  */
 @Entity
-@Data
+@Getter
 @NoArgsConstructor
 @Table(name = "user")
 public class User implements UserDetails {
@@ -114,6 +115,22 @@ public class User implements UserDetails {
         this.workTime = requestDto.getWorkTime();
         this.wage = requestDto.getWage();
         this.store = store;
+    }
+
+    /**
+     * 유저프로필코드를 설정하는 메소드
+     * @param code
+     */
+    public void setUserProfileCode(int code) {
+        this.userProfileCode = code;
+    }
+
+    /**
+     * 카카오 이메일이 null일 시 이메일을 저장하는 메소드
+     * @param email 저장할 임의의 메소드
+     */
+    public void setKakaoEmail(String email) {
+        this.kakaoEmail = email;
     }
 
     @Override

--- a/src/main/java/dnd/dnd10_backend/user/repository/UserRepository.java
+++ b/src/main/java/dnd/dnd10_backend/user/repository/UserRepository.java
@@ -26,6 +26,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     public User findByUserCode(Long userCode);
 
+    public User findByKakaoId(Long id);
+
     public List<User> findByKakaoNickname(String userName);
 
     public User findByKakaoNicknameAndUserProfileCode(String userName, int userProfileCode);

--- a/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
+++ b/src/main/java/dnd/dnd10_backend/user/service/TokenService.java
@@ -112,11 +112,7 @@ public class TokenService {
         KakaoProfile profile = findProfile(token);
         List<String> tokenList = new ArrayList<>();
 
-//        if(profile.getKakao_account().getEmail().equals(null)) {
-//            throw new CustomerNotFoundException(CodeStatus.USER_EMAIL_NULL);
-//        }
-
-        User user = userRepository.findByKakaoEmail(profile.getKakao_account().getEmail());
+        User user = userRepository.findByKakaoId(profile.getId());
 
         if(user == null) {
             user = User.builder()
@@ -126,7 +122,13 @@ public class TokenService {
                     .wage(0)
                     .userRole("ROLE_USER").build();
 
-            userRepository.save(user);
+            user = userRepository.save(user);
+
+            if(user.getKakaoEmail().equals(null)) {
+                String email = "temp" + user.getUserCode() +"@wise.com";
+                user.setKakaoEmail(email);
+                userRepository.save(user);
+            }
         }
 
         //List에 각각 access token과 refresh token 차례로 넣어줌


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/#132-kakao-email -> develop

### 변경 사항
- 카카오 소셜로그인 시 카카오 이메일 미동의할 경우 임의의 이메일을 넣어줍니다.

### 이슈 번호
https://github.com/dnd-side-project/dnd-8th-10-backend/issues/132
