### PR TITLE
hotfix: 시재 업데이트 시 시재 기록에 카테고리 저장안되는 에러 해결

### DIFF
--- a/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryListRequestDto.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/dto/request/UpdateInventoryListRequestDto.java
@@ -24,6 +24,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdateInventoryListRequestDto {
-    private Category category;
+    private String category;
     private List<UpdateInventoryRequestDto> list;
 }

--- a/src/main/java/dnd/dnd10_backend/Inventory/service/InventoryService.java
+++ b/src/main/java/dnd/dnd10_backend/Inventory/service/InventoryService.java
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -109,10 +110,10 @@ public class InventoryService {
      * @param token access token
      * @return 응답해주려는 inventory 정보 목록
      */
-    public List<InventoryResponseDto> updateInventory(UpdateInventoryListRequestDto listRequestDto, final String token){
+    public List<InventoryResponseDto> updateInventory(final UpdateInventoryListRequestDto listRequestDto, final String token){
         User user = userService.getUserByEmail(token);
         Store store = user.getStore();
-        Category category = listRequestDto.getCategory();
+        Category category = Category.valueOf(listRequestDto.getCategory().toUpperCase(Locale.ROOT));
 
         List<UpdateInventoryRequestDto> list = listRequestDto.getList();
         TimeCard timeCard = findTimeCard(user, store);
@@ -145,9 +146,6 @@ public class InventoryService {
                         .store(store)
                         .build();
             }
-
-            inventoryUpdateRecordRepository.save(record);
-            
         }
 
         List<Inventory> inventoryList = inventoryRepository.findInventoryByCategoryAndStore(category, store);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
main -> main

### 변경 사항
- 시재 업데이트 시 받는 responseDto의 `category`타입을 Enum의 `Category`에서 String타입으로 변경
- 시재 업데이트 시 responseDto로 부터 받는 `category`정보를 String으로 받아서 Enum타입으로 변경할 수 있도록 수정
